### PR TITLE
Pass --score=n to pylint

### DIFF
--- a/push.py
+++ b/push.py
@@ -35,7 +35,7 @@ REPOS = (
         '--require-serial',
     ),
     ('mirrors-puppet-lint', *lang_pkg('ruby', 'puppet-lint'), PP),
-    ('mirrors-pylint', *lang_pkg('python', 'pylint'), PY),
+    ('mirrors-pylint', *lang_pkg('python', 'pylint'), PY, '--score=n'),
     ('mirrors-ruby-lint', *lang_pkg('ruby', 'ruby-lint'), RB),
     (
         'mirrors-scss-lint',


### PR DESCRIPTION
Discussion in https://github.com/pre-commit/mirrors-pylint/issues/12 - score isn't useful since pre-commit runs in parallel